### PR TITLE
Flag to omit the final commit at end of file or stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Flags.
             write cpu profile to file
       -memprofile string
             write heap profile to file
+      -no-final-commit
+            omit final commit (at end of file or stdin)
       -optimize
             optimize index
       -purge

--- a/cmd/solrbulk/solrbulk.go
+++ b/cmd/solrbulk/solrbulk.go
@@ -164,18 +164,16 @@ func main() {
 		queue <- line
 		i++
 
-		if !*noFinalCommit {
-			if i%options.CommitSize == 0 {
-				resp, err := pester.Get(commitURL)
-				if err != nil {
-					log.Fatal(err)
-				}
-				if options.Verbose {
-					log.Printf("commit @%d %s", i, resp.Status)
-				}
-				if err := resp.Body.Close(); err != nil {
-					log.Fatal(err)
-				}
+		if i%options.CommitSize == 0 {
+			resp, err := pester.Get(commitURL)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if options.Verbose {
+				log.Printf("commit @%d %s", i, resp.Status)
+			}
+			if err := resp.Body.Close(); err != nil {
+				log.Fatal(err)
 			}
 		}
 	}


### PR DESCRIPTION
Within the scope of processing a huge amount of small jsonld files, I observed that the time needed for the final commits add up unproportionaly. To give you an idea of our issue:

    tar -xzf lot_of_small_jsonld_files.tar.gz --to-command="solrbulk -verbose -server http://mysolr/core"

My preferred solution would be as follows:

     # purge
     solrbulk -server http://mysolr/core -purge -purge-query /dev/null
     # load data
     tar -xzf lot_of_small_jsonld_files.tar.gz --to-command="solrbulk -verbose -server http://mysolr/core -no-final-commit"
     tar -xzf even_more_small_jsonld_files.tar.gz --to-command="solrbulk -verbose -server http://mysolr/core -no-final-commit"
     # ....
     # one final commit
     solrbulk -server http://mysolr/core -commit 0 /dev/null
