### PR TITLE
Add basic auth option

### DIFF
--- a/cmd/solrbulk/solrbulk.go
+++ b/cmd/solrbulk/solrbulk.go
@@ -57,6 +57,7 @@ var (
 	purgePause               = flag.Duration("purge-pause", 2*time.Second, "insert a short pause after purge")
 	updateRequestHandlerName = flag.String("update-request-handler-name", "/update", "where solr.UpdateRequestHandler is mounted on the server, https://is.gd/s0eirv")
 	noFinalCommit            = flag.Bool("no-final-commit", false, "omit final commit")
+	basicAuth                = flag.String("auth", "", "username:password pair for basic auth")
 )
 
 func main() {
@@ -79,6 +80,7 @@ func main() {
 		Verbose:                  *verbose,
 		UpdateRequestHandlerName: *updateRequestHandlerName,
 		Server:                   *server,
+		BasicAuth:                *basicAuth,
 	}
 	if !strings.HasPrefix(options.Server, "http") {
 		options.Server = fmt.Sprintf("http://%s", options.Server)

--- a/cmd/solrbulk/solrbulk.go
+++ b/cmd/solrbulk/solrbulk.go
@@ -62,7 +62,7 @@ var (
 	basicAuth                = flag.String("auth", "", "username:password pair for basic auth")
 )
 
-func requestGet(url string, options solrbulk.Options) (*http.Response, error) {
+func newGetRequest(url string, options solrbulk.Options) (*http.Request, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -71,12 +71,7 @@ func requestGet(url string, options solrbulk.Options) (*http.Response, error) {
 	if options.BasicAuth != "" {
 		req.Header.Add("Authorization", "Basic "+b64.StdEncoding.EncodeToString([]byte(options.BasicAuth)))
 	}
-	resp, err := pester.Do(req)
-
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return req, nil
 }
 
 func main() {
@@ -113,7 +108,12 @@ func main() {
 			}
 		)
 		for _, url := range urls {
-			resp, err := requestGet(url, options)
+			req, err := newGetRequest(url, options)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resp, err := pester.Do(req)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -175,7 +175,12 @@ func main() {
 		queue <- line
 		i++
 		if i%options.CommitSize == 0 {
-			resp, err := requestGet(commitURL, options)
+			req, err := newGetRequest(commitURL, options)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resp, err := pester.Do(req)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -205,7 +210,13 @@ func main() {
 	if *optimize {
 		hostpath := fmt.Sprintf("%s%s", options.Server, options.UpdateRequestHandlerName)
 		url := fmt.Sprintf("%s?stream.body=<optimize/>", hostpath)
-		resp, err := requestGet(url, options)
+
+		req, err := newGetRequest(url, options)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		resp, err := pester.Do(req)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/worker.go
+++ b/worker.go
@@ -23,10 +23,12 @@
 package solrbulk
 
 import (
+	b64 "encoding/base64"
 	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -47,6 +49,23 @@ type Options struct {
 	UpdateRequestHandlerName string
 	BasicAuth                string
 }
+
+func requestPost(url string, body string, options Options) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	if options.BasicAuth  != "" {
+		req.Header.Add("Authorization", "Basic "+ b64.StdEncoding.EncodeToString([]byte(options.BasicAuth)))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := pester.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // BulkIndex takes a set of documents as strings and indexes them into SOLR.
@@ -61,7 +80,9 @@ func BulkIndex(docs []string, options Options) error {
 		lines = append(lines, doc)
 	}
 	body := fmt.Sprintf("[%s]\n", strings.Join(lines, ","))
-	resp, err := pester.Post(link, "application/json", strings.NewReader(body))
+
+	resp, err := requestPost(link, body, options)
+
 	if err != nil {
 		return err
 	}

--- a/worker.go
+++ b/worker.go
@@ -45,6 +45,8 @@ type Options struct {
 	Verbose                  bool
 	Server                   string
 	UpdateRequestHandlerName string
+	BasicAuth                string
+}
 }
 
 // BulkIndex takes a set of documents as strings and indexes them into SOLR.

--- a/worker.go
+++ b/worker.go
@@ -50,7 +50,7 @@ type Options struct {
 	BasicAuth                string
 }
 
-func requestPost(url string, body string, options Options) (*http.Response, error) {
+func newPostRequest(url string, body string, options Options) (*http.Request, error) {
 	req, err := http.NewRequest("POST", url, strings.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -60,12 +60,7 @@ func requestPost(url string, body string, options Options) (*http.Response, erro
 		req.Header.Add("Authorization", "Basic "+ b64.StdEncoding.EncodeToString([]byte(options.BasicAuth)))
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := pester.Do(req)
-
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return req, nil
 }
 
 // BulkIndex takes a set of documents as strings and indexes them into SOLR.
@@ -81,8 +76,12 @@ func BulkIndex(docs []string, options Options) error {
 	}
 	body := fmt.Sprintf("[%s]\n", strings.Join(lines, ","))
 
-	resp, err := requestPost(link, body, options)
+	req, err := newPostRequest(link, body, options)
+	if err != nil {
+		return err
+	}
 
+	resp, err := pester.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds the option `-auth` to set basic auth credentials. Those are added to each request header.

CLI (Preview):

```
$ solrbulk -h                                                                                                   
Usage of solrbulk:
  -auth string
        username:password pair for basic auth
```