### PR TITLE
Ensure auth on final commit, if set

### DIFF
--- a/cmd/solrbulk/solrbulk.go
+++ b/cmd/solrbulk/solrbulk.go
@@ -162,7 +162,12 @@ func main() {
 	}
 	if !*noFinalCommit {
 		defer func() {
-			resp, err := pester.Get(commitURL)
+			req, err := newGetRequest(commitURL, options)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resp, err := pester.Do(req)
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
Hi,

the final commit option is not using basic auth (even if set).

```
solrbulk -auth "solr:solr" ...
...
INFO[0002] final commit: 401 Unauthorized
```

Here is my fix.